### PR TITLE
fix: harden vfs wrapper and streaming edge cases

### DIFF
--- a/lib/jido_vfs.ex
+++ b/lib/jido_vfs.ex
@@ -854,7 +854,8 @@ defmodule Jido.VFS do
 
   # Same adapter, same config -> just do a plain copy
   def copy_between_filesystem({filesystem, source}, {filesystem, destination}, opts) do
-    with {:ok, _strategy} <- copy_between_strategy_from_opts(opts) do
+    with {:ok, _strategy} <- copy_between_strategy_from_opts(opts),
+         {:ok, _chunk_size} <- copy_between_chunk_size_from_opts(opts) do
       copy(filesystem, source, destination, copy_between_runtime_opts(opts))
     end
   end
@@ -925,15 +926,21 @@ defmodule Jido.VFS do
   end
 
   defp copy_between_with_strategy(source, destination, :stream, opts) do
-    copy_via_stream(source, destination, copy_between_runtime_opts(opts))
+    copy_via_stream(source, destination, opts)
   end
 
   defp copy_between_with_strategy(source, destination, :tempfile, opts) do
-    copy_via_tempfile(source, destination, Keyword.delete(opts, :copy_between_strategy))
+    copy_via_tempfile(source, destination, opts)
   end
 
   defp copy_between_runtime_opts(opts) do
-    Keyword.drop(opts, [:copy_between_strategy, :copy_between_temp_dir])
+    Keyword.drop(opts, [:copy_between_strategy, :copy_between_temp_dir, :chunk_size])
+  end
+
+  defp copy_between_stream_opts(opts, chunk_size) do
+    opts
+    |> copy_between_runtime_opts()
+    |> Keyword.put(:chunk_size, chunk_size)
   end
 
   defp copy_between_strategy_from_opts(opts) do
@@ -959,17 +966,18 @@ defmodule Jido.VFS do
          {destination_filesystem, destination_path},
          opts
        ) do
-    chunk_size = normalize_copy_chunk_size(Keyword.get(opts, :chunk_size, 64 * 1024))
-    adapter_opts = Keyword.drop(opts, [:copy_between_temp_dir])
-    stream_opts = Keyword.put(adapter_opts, :chunk_size, chunk_size)
+    adapter_opts = copy_between_runtime_opts(opts)
 
-    with {:ok, chunks} <- source_copy_chunks(source_filesystem, source_path, stream_opts, chunk_size),
+    with {:ok, chunk_size} <- copy_between_chunk_size_from_opts(opts),
+         stream_opts = copy_between_stream_opts(opts, chunk_size),
+         {:ok, chunks} <- source_copy_chunks(source_filesystem, source_path, stream_opts, chunk_size),
          :ok <-
            write_copy_chunks_to_destination(
              destination_filesystem,
              destination_path,
              chunks,
              stream_opts,
+             adapter_opts,
              chunk_size
            ) do
       :ok
@@ -990,10 +998,18 @@ defmodule Jido.VFS do
     end
   end
 
-  defp write_copy_chunks_to_destination(destination_filesystem, destination_path, chunks, opts, _chunk_size) do
+  defp write_copy_chunks_to_destination(
+         destination_filesystem,
+         destination_path,
+         chunks,
+         stream_opts,
+         adapter_opts,
+         _chunk_size
+       ) do
     cond do
       supports?(destination_filesystem, :write_stream) ->
-        with {:ok, write_stream} <- open_destination_write_stream(destination_filesystem, destination_path, opts) do
+        with {:ok, write_stream} <-
+               open_destination_write_stream(destination_filesystem, destination_path, stream_opts, adapter_opts) do
           try do
             Enum.into(chunks, write_stream)
             :ok
@@ -1010,10 +1026,10 @@ defmodule Jido.VFS do
         end
 
       supports?(destination_filesystem, :append) ->
-        with :ok <- Jido.VFS.write(destination_filesystem, destination_path, "", opts) do
+        with :ok <- Jido.VFS.write(destination_filesystem, destination_path, "", adapter_opts) do
           try do
             Enum.reduce_while(chunks, :ok, fn chunk, :ok ->
-              case Jido.VFS.append(destination_filesystem, destination_path, chunk, opts) do
+              case Jido.VFS.append(destination_filesystem, destination_path, chunk, adapter_opts) do
                 :ok -> {:cont, :ok}
                 {:error, reason} -> {:halt, copy_side_error(:destination, destination_path, reason)}
               end
@@ -1037,7 +1053,7 @@ defmodule Jido.VFS do
             |> Enum.reduce([], fn chunk, acc -> [acc, chunk] end)
             |> IO.iodata_to_binary()
 
-          case Jido.VFS.write(destination_filesystem, destination_path, contents, opts) do
+          case Jido.VFS.write(destination_filesystem, destination_path, contents, adapter_opts) do
             :ok -> :ok
             {:error, reason} -> copy_side_error(:destination, destination_path, reason)
           end
@@ -1056,11 +1072,13 @@ defmodule Jido.VFS do
          {destination_filesystem, destination_path},
          opts
        ) do
-    chunk_size = normalize_copy_chunk_size(Keyword.get(opts, :chunk_size, 64 * 1024))
     temp_dir = Keyword.get(opts, :copy_between_temp_dir, System.tmp_dir!())
-    adapter_opts = Keyword.drop(opts, [:copy_between_temp_dir])
+    adapter_opts = copy_between_runtime_opts(opts)
 
-    with :ok <- ensure_copy_temp_dir(temp_dir) do
+    with {:ok, chunk_size} <- copy_between_chunk_size_from_opts(opts),
+         :ok <- ensure_copy_temp_dir(temp_dir) do
+      stream_opts = copy_between_stream_opts(opts, chunk_size)
+
       temp_path =
         Path.join(
           temp_dir,
@@ -1069,13 +1087,14 @@ defmodule Jido.VFS do
 
       try do
         with :ok <-
-               copy_source_into_tempfile(source_filesystem, source_path, temp_path, adapter_opts, chunk_size),
+               copy_source_into_tempfile(source_filesystem, source_path, temp_path, stream_opts, chunk_size),
              :ok <-
                copy_tempfile_into_destination(
                  destination_filesystem,
                  destination_path,
                  temp_path,
                  adapter_opts,
+                 stream_opts,
                  chunk_size
                ) do
           :ok
@@ -1109,8 +1128,22 @@ defmodule Jido.VFS do
     end
   end
 
-  defp normalize_copy_chunk_size(size) when is_integer(size) and size > 0, do: size
-  defp normalize_copy_chunk_size(_), do: 64 * 1024
+  defp copy_between_chunk_size_from_opts(opts) do
+    case Keyword.get(opts, :chunk_size, 64 * 1024) do
+      size when is_integer(size) and size > 0 ->
+        {:ok, size}
+
+      size ->
+        {:error,
+         Errors.AdapterError.exception(
+           adapter: __MODULE__,
+           reason: %{
+             operation: :copy_between_filesystem,
+             reason: {:invalid_chunk_size, size}
+           }
+         )}
+    end
+  end
 
   defp normalize_copy_paths(source_path, destination_path) do
     case Jido.VFS.RelativePath.normalize(source_path) do
@@ -1165,6 +1198,7 @@ defmodule Jido.VFS do
          destination_path,
          temp_path,
          opts,
+         stream_opts,
          chunk_size
        ) do
     if supports?(destination_filesystem, :write_stream) do
@@ -1172,7 +1206,8 @@ defmodule Jido.VFS do
              open_destination_write_stream(
                destination_filesystem,
                destination_path,
-               Keyword.put(opts, :chunk_size, chunk_size)
+               stream_opts,
+               opts
              ) do
         try do
           temp_path
@@ -1249,9 +1284,9 @@ defmodule Jido.VFS do
     end
   end
 
-  defp open_destination_write_stream(destination_filesystem, destination_path, opts) do
-    with :ok <- ensure_destination_write_target(destination_filesystem, destination_path, opts),
-         {:ok, write_stream} <- Jido.VFS.write_stream(destination_filesystem, destination_path, opts) do
+  defp open_destination_write_stream(destination_filesystem, destination_path, stream_opts, adapter_opts) do
+    with :ok <- ensure_destination_write_target(destination_filesystem, destination_path, adapter_opts),
+         {:ok, write_stream} <- Jido.VFS.write_stream(destination_filesystem, destination_path, stream_opts) do
       {:ok, write_stream}
     end
   end
@@ -1275,14 +1310,22 @@ defmodule Jido.VFS do
   @doc false
   # Also used by the InMemory adapter and therefore not private
   @spec chunk(binary(), pos_integer()) :: [binary()]
-  def chunk("", _size), do: []
-
-  def chunk(binary, size) when byte_size(binary) >= size do
-    {chunk, rest} = :erlang.split_binary(binary, size)
-    [chunk | chunk(rest, size)]
+  def chunk(binary, size) when is_integer(size) and size > 0 do
+    do_chunk(binary, size)
   end
 
-  def chunk(binary, _size), do: [binary]
+  def chunk(_binary, size) do
+    raise ArgumentError, "chunk size must be a positive integer, got: #{inspect(size)}"
+  end
+
+  defp do_chunk("", _size), do: []
+
+  defp do_chunk(binary, size) when byte_size(binary) >= size do
+    {chunk, rest} = :erlang.split_binary(binary, size)
+    [chunk | do_chunk(rest, size)]
+  end
+
+  defp do_chunk(binary, _size), do: [binary]
 
   defp normalize_revision_result({:ok, revisions}) when is_list(revisions) do
     {:ok, Enum.map(revisions, &to_revision_struct/1)}

--- a/lib/jido_vfs/adapter/in_memory.ex
+++ b/lib/jido_vfs/adapter/in_memory.ex
@@ -168,12 +168,21 @@ defmodule Jido.VFS.Adapter.InMemory do
 
   @impl Jido.VFS.Adapter
   def read_stream(config, path, opts) do
-    {:ok,
-     %AgentStream{
-       config: config,
-       path: path,
-       chunk_size: Keyword.get(opts, :chunk_size, 1024)
-     }}
+    case file_exists(config, path) do
+      {:ok, :exists} ->
+        {:ok,
+         %AgentStream{
+           config: config,
+           path: path,
+           chunk_size: Keyword.get(opts, :chunk_size, 1024)
+         }}
+
+      {:ok, :missing} ->
+        {:error, Errors.FileNotFound.exception(file_path: path)}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   @impl Jido.VFS.Adapter

--- a/lib/jido_vfs/adapter/local.ex
+++ b/lib/jido_vfs/adapter/local.ex
@@ -110,9 +110,19 @@ defmodule Jido.VFS.Adapter.Local do
 
   @impl Jido.VFS.Adapter
   def write_stream(%Config{} = config, path, opts) do
+    path = full_path(config, path)
     modes = opts[:modes] || []
     line_or_bytes = opts[:chunk_size] || :line
-    {:ok, File.stream!(full_path(config, path), modes, line_or_bytes)}
+
+    with :ok <- ensure_directory(config, Path.dirname(path), opts) do
+      {:ok, File.stream!(path, line_or_bytes, modes)}
+    else
+      {:error, reason} when is_atom(reason) ->
+        {:error, convert_file_error(reason, path)}
+
+      {:error, %{__struct__: _} = error} ->
+        {:error, error}
+    end
   rescue
     e -> {:error, convert_exception_error(e, full_path(config, path))}
   end
@@ -129,7 +139,7 @@ defmodule Jido.VFS.Adapter.Local do
   def read_stream(%Config{} = config, path, opts) do
     modes = opts[:modes] || []
     line_or_bytes = opts[:chunk_size] || :line
-    {:ok, File.stream!(full_path(config, path), modes, line_or_bytes)}
+    {:ok, File.stream!(full_path(config, path), line_or_bytes, modes)}
   rescue
     e -> {:error, convert_exception_error(e, full_path(config, path))}
   end

--- a/lib/jido_vfs/adapter/local.ex
+++ b/lib/jido_vfs/adapter/local.ex
@@ -110,15 +110,15 @@ defmodule Jido.VFS.Adapter.Local do
 
   @impl Jido.VFS.Adapter
   def write_stream(%Config{} = config, path, opts) do
-    path = full_path(config, path)
+    target_path = full_path(config, path)
     modes = opts[:modes] || []
     line_or_bytes = opts[:chunk_size] || :line
 
-    with :ok <- ensure_directory(config, Path.dirname(path), opts) do
-      {:ok, File.stream!(path, line_or_bytes, modes)}
+    with :ok <- ensure_directory(config, Path.dirname(target_path), opts) do
+      {:ok, File.stream!(target_path, line_or_bytes, modes)}
     else
       {:error, reason} when is_atom(reason) ->
-        {:error, convert_file_error(reason, path)}
+        {:error, convert_file_error(reason, target_path)}
 
       {:error, %{__struct__: _} = error} ->
         {:error, error}
@@ -137,9 +137,20 @@ defmodule Jido.VFS.Adapter.Local do
 
   @impl Jido.VFS.Adapter
   def read_stream(%Config{} = config, path, opts) do
+    target_path = full_path(config, path)
     modes = opts[:modes] || []
     line_or_bytes = opts[:chunk_size] || :line
-    {:ok, File.stream!(full_path(config, path), line_or_bytes, modes)}
+
+    case File.stat(target_path) do
+      {:ok, %{type: :regular}} ->
+        {:ok, File.stream!(target_path, line_or_bytes, modes)}
+
+      {:ok, _stat} ->
+        {:error, convert_file_error(:eisdir, target_path)}
+
+      {:error, reason} ->
+        {:error, convert_file_error(reason, target_path)}
+    end
   rescue
     e -> {:error, convert_exception_error(e, full_path(config, path))}
   end

--- a/lib/jido_vfs/adapter/s3.ex
+++ b/lib/jido_vfs/adapter/s3.ex
@@ -288,7 +288,7 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def write(%Config{} = config, path, contents, opts) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
 
     if visibility = Keyword.get(opts, :visibility) do
       store_visibility(config, path, visibility)
@@ -319,7 +319,7 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def write_stream(%Config{} = config, path, opts) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
 
     {:ok,
      %StreamUpload{
@@ -331,7 +331,7 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def read(%Config{} = config, path) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
 
     operation = ExAws.S3.get_object(config.bucket, path)
 
@@ -352,9 +352,9 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def read_stream(%Config{} = config, path, opts) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
 
-    with {:ok, :exists} <- file_exists(config, path) do
+    with {:ok, :exists} <- object_exists(config, path) do
       op = ExAws.S3.download_file(config.bucket, path, "", opts)
 
       stream =
@@ -379,18 +379,9 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def delete(%Config{} = config, path) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
 
-    operation = ExAws.S3.delete_object(config.bucket, path)
-
-    case ExAws.request(operation, config.config) do
-      {:ok, _} ->
-        delete_stored_visibility(config, path)
-        :ok
-
-      {:error, error} ->
-        {:error, %Errors.AdapterError{adapter: __MODULE__, reason: error}}
-    end
+    delete_object(config, path)
   end
 
   @impl Jido.VFS.Adapter
@@ -402,12 +393,12 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def copy(%Config{} = source_config, source, %Config{} = dest_config, destination, opts) do
-    source = clean_path(Jido.VFS.RelativePath.join_prefix(source_config.prefix, source))
-    destination = clean_path(Jido.VFS.RelativePath.join_prefix(dest_config.prefix, destination))
+    source_path = object_path(source_config, source)
+    destination_path = object_path(dest_config, destination)
 
     case {source_config.config, dest_config.config} do
       {config, config} ->
-        do_copy(config, {source_config.bucket, source}, {dest_config.bucket, destination}, opts)
+        do_copy(config, {source_config.bucket, source_path}, {dest_config.bucket, destination_path}, opts)
 
       _ ->
         with {:ok, content} <- read(source_config, source),
@@ -451,27 +442,18 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def file_exists(%Config{} = config, path) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
-
-    operation = ExAws.S3.head_object(config.bucket, path)
-
-    case ExAws.request(operation, config.config) do
-      {:ok, _} ->
-        {:ok, :exists}
-
-      {:error, {:http_error, 404, _}} ->
-        {:ok, :missing}
-
-      {:error, error} ->
-        {:error, %Errors.AdapterError{adapter: __MODULE__, reason: error}}
-    end
+    object_exists(config, object_path(config, path))
   end
 
   @impl Jido.VFS.Adapter
   def list_contents(%Config{} = config, path) do
-    base_path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    base_path = object_path(config, path)
     list_prefix = if path in ["", "."], do: clear_prefix(config), else: base_path
 
+    list_contents_at_prefix(config, list_prefix)
+  end
+
+  defp list_contents_at_prefix(config, list_prefix) do
     with {:ok, %{contents: contents, common_prefixes: prefixes}} <-
            list_objects_paginated(config, list_prefix, "/") do
       directories =
@@ -520,7 +502,7 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def delete_directory(config, path, opts) do
-    path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    path = object_path(config, path)
     path = if String.ends_with?(path, "/"), do: path, else: path <> "/"
 
     if Keyword.get(opts, :recursive, false) do
@@ -533,9 +515,9 @@ defmodule Jido.VFS.Adapter.S3 do
           error
       end
     else
-      case list_contents(config, path) do
+      case list_contents_at_prefix(config, path) do
         {:ok, []} ->
-          case delete(config, String.trim_trailing(path, "/")) do
+          case delete_object(config, path) do
             :ok ->
               delete_stored_visibility_prefix(config, path)
               :ok
@@ -569,19 +551,25 @@ defmodule Jido.VFS.Adapter.S3 do
 
   @impl Jido.VFS.Adapter
   def set_visibility(%Config{} = config, path, visibility) do
-    normalized_path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    normalized_path = object_path(config, path)
     store_visibility(config, normalized_path, visibility)
     :ok
   end
 
   @impl Jido.VFS.Adapter
   def visibility(%Config{} = config, path) do
-    normalized_path = clean_path(Jido.VFS.RelativePath.join_prefix(config.prefix, path))
+    normalized_path = object_path(config, path)
     visibility = get_stored_visibility(config, normalized_path)
     {:ok, visibility}
   end
 
   # Helper Functions
+
+  defp object_path(%Config{} = config, path) do
+    config.prefix
+    |> Jido.VFS.RelativePath.join_prefix(path)
+    |> clean_path()
+  end
 
   defp clean_path(path) do
     case path do
@@ -625,6 +613,34 @@ defmodule Jido.VFS.Adapter.S3 do
 
   defp visibility_key_matches_prefix?(path, path_prefix, normalized_prefix) do
     path == normalized_prefix or String.starts_with?(path, path_prefix)
+  end
+
+  defp object_exists(%Config{} = config, path) do
+    operation = ExAws.S3.head_object(config.bucket, path)
+
+    case ExAws.request(operation, config.config) do
+      {:ok, _} ->
+        {:ok, :exists}
+
+      {:error, {:http_error, 404, _}} ->
+        {:ok, :missing}
+
+      {:error, error} ->
+        {:error, %Errors.AdapterError{adapter: __MODULE__, reason: error}}
+    end
+  end
+
+  defp delete_object(%Config{} = config, path) do
+    operation = ExAws.S3.delete_object(config.bucket, path)
+
+    case ExAws.request(operation, config.config) do
+      {:ok, _} ->
+        delete_stored_visibility(config, path)
+        :ok
+
+      {:error, error} ->
+        {:error, %Errors.AdapterError{adapter: __MODULE__, reason: error}}
+    end
   end
 
   defp stream_chunk_or_raise({:ok, {start_byte, chunk}}) when is_integer(start_byte), do: chunk

--- a/lib/jido_vfs/adapter/s3.ex
+++ b/lib/jido_vfs/adapter/s3.ex
@@ -374,6 +374,9 @@ defmodule Jido.VFS.Adapter.S3 do
     else
       {:ok, :missing} ->
         {:error, %Errors.FileNotFound{file_path: path}}
+
+      {:error, _} = error ->
+        error
     end
   end
 

--- a/lib/jido_vfs/filesystem.ex
+++ b/lib/jido_vfs/filesystem.ex
@@ -6,7 +6,13 @@ defmodule Jido.VFS.Filesystem do
   @doc """
   Writes contents to the given relative path.
   """
-  @callback write(path :: Path.t(), contents :: binary, opts :: keyword()) :: :ok | {:error, term}
+  @callback write(path :: Path.t(), contents :: iodata(), opts :: keyword()) :: :ok | {:error, term}
+
+  @doc """
+  Opens a writable stream for the given relative path.
+  """
+  @callback write_stream(path :: Path.t(), opts :: keyword()) ::
+              {:ok, Collectable.t()} | {:error, term}
 
   @doc """
   Reads the file at the given relative path.
@@ -47,6 +53,81 @@ defmodule Jido.VFS.Filesystem do
   """
   @callback list_contents(path :: Path.t(), opts :: keyword()) ::
               {:ok, [%Jido.VFS.Stat.Dir{} | %Jido.VFS.Stat.File{}]} | {:error, term}
+
+  @doc """
+  Creates a directory at the given relative path.
+  """
+  @callback create_directory(path :: Path.t(), opts :: keyword()) :: :ok | {:error, term}
+
+  @doc """
+  Deletes a directory at the given relative path.
+  """
+  @callback delete_directory(path :: Path.t(), opts :: keyword()) :: :ok | {:error, term}
+
+  @doc """
+  Clears the configured filesystem.
+  """
+  @callback clear(opts :: keyword()) :: :ok | {:error, term}
+
+  @doc """
+  Sets public/private visibility for the given relative path.
+  """
+  @callback set_visibility(path :: Path.t(), visibility :: Jido.VFS.Visibility.t()) ::
+              :ok | {:error, term}
+
+  @doc """
+  Reads public/private visibility for the given relative path.
+  """
+  @callback visibility(path :: Path.t()) :: {:ok, Jido.VFS.Visibility.t()} | {:error, term}
+
+  @doc """
+  Reads file or directory metadata for the given relative path.
+  """
+  @callback stat(path :: Path.t()) ::
+              {:ok, %Jido.VFS.Stat.File{} | %Jido.VFS.Stat.Dir{}} | {:error, term}
+
+  @doc """
+  Checks access for the given relative path.
+  """
+  @callback access(path :: Path.t(), modes :: [:read | :write]) :: :ok | {:error, term}
+
+  @doc """
+  Appends contents to the given relative path.
+  """
+  @callback append(path :: Path.t(), contents :: iodata(), opts :: keyword()) ::
+              :ok | {:error, term}
+
+  @doc """
+  Truncates the file at the given relative path.
+  """
+  @callback truncate(path :: Path.t(), new_size :: non_neg_integer()) :: :ok | {:error, term}
+
+  @doc """
+  Updates the modification time for the given relative path.
+  """
+  @callback utime(path :: Path.t(), mtime :: DateTime.t()) :: :ok | {:error, term}
+
+  @doc """
+  Commits changes in version-aware filesystems.
+  """
+  @callback commit(message :: String.t() | nil, opts :: keyword()) :: :ok | {:error, term}
+
+  @doc """
+  Lists revisions for a relative path in version-aware filesystems.
+  """
+  @callback revisions(path :: Path.t(), opts :: keyword()) ::
+              {:ok, [Jido.VFS.Revision.t()]} | {:error, term}
+
+  @doc """
+  Reads a file as it existed at a specific revision.
+  """
+  @callback read_revision(path :: Path.t(), revision :: String.t(), opts :: keyword()) ::
+              {:ok, binary()} | {:error, term}
+
+  @doc """
+  Rolls a version-aware filesystem back to a revision.
+  """
+  @callback rollback(revision :: String.t(), opts :: keyword()) :: :ok | {:error, term}
 
   @doc """
   Injects a filesystem wrapper module backed by a configured adapter.
@@ -98,10 +179,18 @@ defmodule Jido.VFS.Filesystem do
       @doc """
       Writes file contents through the configured filesystem.
       """
-      @spec write(Path.t(), binary(), keyword()) :: :ok | {:error, term()}
+      @spec write(Path.t(), iodata(), keyword()) :: :ok | {:error, term()}
       @impl true
       def write(path, contents, opts \\ []),
         do: Jido.VFS.write(__filesystem__(), path, contents, opts)
+
+      @doc """
+      Opens a writable stream through the configured filesystem.
+      """
+      @spec write_stream(Path.t(), keyword()) :: {:ok, Collectable.t()} | {:error, term()}
+      @impl true
+      def write_stream(path, opts \\ []),
+        do: Jido.VFS.write_stream(__filesystem__(), path, opts)
 
       @doc """
       Reads a file through the configured filesystem.
@@ -159,6 +248,119 @@ defmodule Jido.VFS.Filesystem do
       @impl true
       def list_contents(path, opts \\ []),
         do: Jido.VFS.list_contents(__filesystem__(), path, opts)
+
+      @doc """
+      Creates a directory through the configured filesystem.
+      """
+      @spec create_directory(Path.t(), keyword()) :: :ok | {:error, term()}
+      @impl true
+      def create_directory(path, opts \\ []),
+        do: Jido.VFS.create_directory(__filesystem__(), path, opts)
+
+      @doc """
+      Deletes a directory through the configured filesystem.
+      """
+      @spec delete_directory(Path.t(), keyword()) :: :ok | {:error, term()}
+      @impl true
+      def delete_directory(path, opts \\ []),
+        do: Jido.VFS.delete_directory(__filesystem__(), path, opts)
+
+      @doc """
+      Clears the configured filesystem.
+      """
+      @spec clear(keyword()) :: :ok | {:error, term()}
+      @impl true
+      def clear(opts \\ []),
+        do: Jido.VFS.clear(__filesystem__(), opts)
+
+      @doc """
+      Sets visibility through the configured filesystem.
+      """
+      @spec set_visibility(Path.t(), Jido.VFS.Visibility.t()) :: :ok | {:error, term()}
+      @impl true
+      def set_visibility(path, visibility),
+        do: Jido.VFS.set_visibility(__filesystem__(), path, visibility)
+
+      @doc """
+      Reads visibility through the configured filesystem.
+      """
+      @spec visibility(Path.t()) :: {:ok, Jido.VFS.Visibility.t()} | {:error, term()}
+      @impl true
+      def visibility(path),
+        do: Jido.VFS.visibility(__filesystem__(), path)
+
+      @doc """
+      Reads file or directory metadata through the configured filesystem.
+      """
+      @spec stat(Path.t()) ::
+              {:ok, %Jido.VFS.Stat.File{} | %Jido.VFS.Stat.Dir{}} | {:error, term()}
+      @impl true
+      def stat(path),
+        do: Jido.VFS.stat(__filesystem__(), path)
+
+      @doc """
+      Checks access through the configured filesystem.
+      """
+      @spec access(Path.t(), [:read | :write]) :: :ok | {:error, term()}
+      @impl true
+      def access(path, modes),
+        do: Jido.VFS.access(__filesystem__(), path, modes)
+
+      @doc """
+      Appends file contents through the configured filesystem.
+      """
+      @spec append(Path.t(), iodata(), keyword()) :: :ok | {:error, term()}
+      @impl true
+      def append(path, contents, opts \\ []),
+        do: Jido.VFS.append(__filesystem__(), path, contents, opts)
+
+      @doc """
+      Truncates a file through the configured filesystem.
+      """
+      @spec truncate(Path.t(), non_neg_integer()) :: :ok | {:error, term()}
+      @impl true
+      def truncate(path, new_size),
+        do: Jido.VFS.truncate(__filesystem__(), path, new_size)
+
+      @doc """
+      Updates modification time through the configured filesystem.
+      """
+      @spec utime(Path.t(), DateTime.t()) :: :ok | {:error, term()}
+      @impl true
+      def utime(path, mtime),
+        do: Jido.VFS.utime(__filesystem__(), path, mtime)
+
+      @doc """
+      Commits changes through the configured filesystem.
+      """
+      @spec commit(String.t() | nil, keyword()) :: :ok | {:error, term()}
+      @impl true
+      def commit(message \\ nil, opts \\ []),
+        do: Jido.VFS.commit(__filesystem__(), message, opts)
+
+      @doc """
+      Lists revisions through the configured filesystem.
+      """
+      @spec revisions(Path.t(), keyword()) :: {:ok, [Jido.VFS.Revision.t()]} | {:error, term()}
+      @impl true
+      def revisions(path \\ ".", opts \\ []),
+        do: Jido.VFS.revisions(__filesystem__(), path, opts)
+
+      @doc """
+      Reads a file at a revision through the configured filesystem.
+      """
+      @spec read_revision(Path.t(), String.t(), keyword()) :: {:ok, binary()} | {:error, term()}
+      @impl true
+      def read_revision(path, revision, opts \\ []),
+        do: Jido.VFS.read_revision(__filesystem__(), path, revision, opts)
+
+      @doc """
+      Rolls back through the configured filesystem.
+      """
+      @spec rollback(String.t(), keyword()) :: :ok | {:error, term()}
+      @impl true
+      def rollback(revision, opts \\ []),
+        do: Jido.VFS.rollback(__filesystem__(), revision, opts)
     end
   end
 

--- a/test/jido_vfs/adapter/in_memory_integration_test.exs
+++ b/test/jido_vfs/adapter/in_memory_integration_test.exs
@@ -339,9 +339,8 @@ defmodule Jido.VFS.Adapter.InMemoryIntegrationTest do
       assert result == ["1", "2"]
     end
 
-    test "stream for non-existent file returns empty", %{filesystem: fs} do
-      assert {:ok, stream} = Jido.VFS.read_stream(fs, "missing.txt")
-      assert Enum.to_list(stream) == []
+    test "stream for non-existent file returns typed error", %{filesystem: fs} do
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} = Jido.VFS.read_stream(fs, "missing.txt")
     end
 
     test "stream count fallback works", %{filesystem: fs} do

--- a/test/jido_vfs/adapter/in_memory_test.exs
+++ b/test/jido_vfs/adapter/in_memory_test.exs
@@ -132,15 +132,13 @@ defmodule Jido.VFS.Adapter.InMemoryTest do
       assert Enum.member?(stream, "Hello") == true
     end
 
-    test "stream for non-existent file returns empty", %{test: test} do
+    test "stream for non-existent file returns typed error", %{test: test} do
       {_, config} = filesystem = Jido.VFS.Adapter.InMemory.configure(name: test)
 
       start_supervised(filesystem)
 
-      assert {:ok, stream} =
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} =
                Jido.VFS.Adapter.InMemory.read_stream(config, "missing.txt", [])
-
-      assert Enum.to_list(stream) == []
     end
 
     test "stream suspend and resume functionality", %{test: test} do
@@ -465,6 +463,25 @@ defmodule Jido.VFS.Adapter.InMemoryTest do
                  "missing.txt",
                  DateTime.utc_now()
                )
+    end
+  end
+
+  describe "copy_between_filesystem" do
+    test "stream strategy returns file not found for missing source", %{test: test} do
+      source = Jido.VFS.Adapter.InMemory.configure(name: :"#{test}_source")
+      destination = Jido.VFS.Adapter.InMemory.configure(name: :"#{test}_destination")
+
+      start_supervised!({Jido.VFS.Adapter.InMemory, source}, id: {test, :source})
+      start_supervised!({Jido.VFS.Adapter.InMemory, destination}, id: {test, :destination})
+
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} =
+               Jido.VFS.copy_between_filesystem(
+                 {source, "missing.txt"},
+                 {destination, "copied.txt"},
+                 copy_between_strategy: :stream
+               )
+
+      assert {:ok, :missing} = Jido.VFS.file_exists(destination, "copied.txt")
     end
   end
 

--- a/test/jido_vfs/adapter/local_integration_test.exs
+++ b/test/jido_vfs/adapter/local_integration_test.exs
@@ -574,12 +574,8 @@ defmodule Jido.VFS.Adapter.LocalIntegrationTest do
       assert :ok = Jido.VFS.delete(fs, "partial.txt")
     end
 
-    test "stream on missing file raises on enumeration", %{filesystem: fs} do
-      {:ok, stream} = Jido.VFS.read_stream(fs, "missing.txt")
-
-      assert_raise File.Error, fn ->
-        Enum.into(stream, <<>>)
-      end
+    test "stream on missing file returns typed error", %{filesystem: fs} do
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} = Jido.VFS.read_stream(fs, "missing.txt")
     end
   end
 

--- a/test/jido_vfs/adapter/local_test.exs
+++ b/test/jido_vfs/adapter/local_test.exs
@@ -56,6 +56,17 @@ defmodule Jido.VFS.Adapter.LocalTest do
       assert {:ok, "Hello World"} = File.read(Path.join(prefix, "test.txt"))
     end
 
+    test "stream creates missing parent directories", %{tmp_dir: prefix} do
+      {_, config} = Jido.VFS.Adapter.Local.configure(prefix: prefix)
+
+      assert {:ok, %File.Stream{} = stream} =
+               Jido.VFS.Adapter.Local.write_stream(config, "nested/stream.txt", [])
+
+      Enum.into(["Hello", " ", "World"], stream)
+
+      assert {:ok, "Hello World"} = File.read(Path.join(prefix, "nested/stream.txt"))
+    end
+
     test "default visibility", %{tmp_dir: prefix} do
       {_, config} = Jido.VFS.Adapter.Local.configure(prefix: prefix)
 

--- a/test/jido_vfs/adapter/local_test.exs
+++ b/test/jido_vfs/adapter/local_test.exs
@@ -111,6 +111,7 @@ defmodule Jido.VFS.Adapter.LocalTest do
 
     test "stream options", %{tmp_dir: prefix} do
       {_, config} = Jido.VFS.Adapter.Local.configure(prefix: prefix)
+      :ok = File.write(Path.join(prefix, "test.txt"), "Hello World")
 
       assert {:ok, %File.Stream{line_or_bytes: :line, modes: [:raw, :read_ahead, :binary]}} =
                Jido.VFS.Adapter.Local.read_stream(config, "test.txt", [])
@@ -131,6 +132,13 @@ defmodule Jido.VFS.Adapter.LocalTest do
                Jido.VFS.Adapter.Local.read_stream(config, "test.txt", [])
 
       assert Enum.into(stream, <<>>) == "Hello World"
+    end
+
+    test "stream for non-existent file returns typed error", %{tmp_dir: prefix} do
+      {_, config} = Jido.VFS.Adapter.Local.configure(prefix: prefix)
+
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} =
+               Jido.VFS.Adapter.Local.read_stream(config, "missing.txt", [])
     end
   end
 

--- a/test/jido_vfs/adapter/s3_integration_test.exs
+++ b/test/jido_vfs/adapter/s3_integration_test.exs
@@ -805,9 +805,6 @@ defmodule Jido.VFS.Adapter.S3IntegrationTest do
     end
 
     test "files under different prefixes are readable independently", %{raw_config: config} do
-      # Note: S3 adapter's list_contents with prefix shows all objects in bucket
-      # because list_objects_v2 uses the prefix from config differently.
-      # This test verifies files are readable under their respective prefixes.
       fs_a = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "list_a/")
       fs_b = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "list_b/")
 
@@ -823,6 +820,12 @@ defmodule Jido.VFS.Adapter.S3IntegrationTest do
       # Files under different prefixes are not accessible from wrong filesystem
       assert {:error, %Jido.VFS.Errors.FileNotFound{}} = Jido.VFS.read(fs_a, "b1.txt")
       assert {:error, %Jido.VFS.Errors.FileNotFound{}} = Jido.VFS.read(fs_b, "a1.txt")
+
+      assert {:ok, list_a} = Jido.VFS.list_contents(fs_a, ".")
+      assert {:ok, list_b} = Jido.VFS.list_contents(fs_b, ".")
+
+      assert Enum.map(list_a, & &1.name) |> Enum.sort() == ["a1.txt", "a2.txt"]
+      assert Enum.map(list_b, & &1.name) == ["b1.txt"]
     end
 
     test "delete with prefix only affects prefixed files", %{raw_config: config} do

--- a/test/jido_vfs/adapter/s3_test.exs
+++ b/test/jido_vfs/adapter/s3_test.exs
@@ -55,6 +55,37 @@ defmodule Jido.VFS.Adapter.S3Test do
       assert {:ok, :missing} = Jido.VFS.file_exists(filesystem_a, "empty/")
       assert {:ok, :exists} = Jido.VFS.file_exists(filesystem_b, "empty/")
     end
+
+    test "root list_contents only returns entries under configured prefix", %{config: config} do
+      filesystem_a = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "list_a")
+      filesystem_b = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "list_b")
+
+      :ok = Jido.VFS.write(filesystem_a, "a.txt", "A")
+      :ok = Jido.VFS.write(filesystem_b, "b.txt", "B")
+
+      assert {:ok, contents_a} = Jido.VFS.list_contents(filesystem_a, ".")
+      assert {:ok, contents_b} = Jido.VFS.list_contents(filesystem_b, ".")
+
+      assert Enum.map(contents_a, & &1.name) == ["a.txt"]
+      assert Enum.map(contents_b, & &1.name) == ["b.txt"]
+    end
+
+    test "native copy_between_filesystem honors source and destination prefixes", %{config: config} do
+      filesystem_a = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "copy_a")
+      filesystem_b = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "copy_b")
+
+      :ok = Jido.VFS.write(filesystem_a, "source.txt", "prefixed copy")
+
+      assert :ok =
+               Jido.VFS.copy_between_filesystem(
+                 {filesystem_a, "source.txt"},
+                 {filesystem_b, "copied.txt"},
+                 copy_between_strategy: :native
+               )
+
+      assert {:ok, "prefixed copy"} = Jido.VFS.read(filesystem_b, "copied.txt")
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} = Jido.VFS.read(filesystem_b, "source.txt")
+    end
   end
 
   describe "cross bucket" do

--- a/test/jido_vfs/adapter/s3_test.exs
+++ b/test/jido_vfs/adapter/s3_test.exs
@@ -29,6 +29,34 @@ defmodule Jido.VFS.Adapter.S3Test do
     {:ok, filesystem: filesystem}
   end
 
+  describe "prefix handling" do
+    test "read_stream honors configured prefix", %{config: config} do
+      filesystem = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "stream_prefix")
+      content = :crypto.strong_rand_bytes(16_384)
+
+      :ok = Jido.VFS.write(filesystem, "file.bin", content)
+
+      assert {:ok, stream} = Jido.VFS.read_stream(filesystem, "file.bin")
+      assert Enum.into(stream, <<>>) == content
+    end
+
+    test "non-recursive delete_directory honors configured prefix", %{config: config} do
+      filesystem_a = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "delete_a")
+      filesystem_b = Jido.VFS.Adapter.S3.configure(config: config, bucket: "default", prefix: "delete_b")
+
+      :ok = Jido.VFS.create_directory(filesystem_a, "empty/")
+      :ok = Jido.VFS.create_directory(filesystem_b, "empty/")
+
+      assert {:ok, :exists} = Jido.VFS.file_exists(filesystem_a, "empty/")
+      assert {:ok, :exists} = Jido.VFS.file_exists(filesystem_b, "empty/")
+
+      assert :ok = Jido.VFS.delete_directory(filesystem_a, "empty/")
+
+      assert {:ok, :missing} = Jido.VFS.file_exists(filesystem_a, "empty/")
+      assert {:ok, :exists} = Jido.VFS.file_exists(filesystem_b, "empty/")
+    end
+  end
+
   describe "cross bucket" do
     setup %{config: config} do
       config_b = JidoVfsTest.Minio.config()

--- a/test/jido_vfs_test.exs
+++ b/test/jido_vfs_test.exs
@@ -30,6 +30,46 @@ defmodule JidoVFSTest do
     def copy(_source_config, _source, _destination_config, _destination, _opts), do: :ok
   end
 
+  defmodule CopyOptionCheckingAdapter do
+    @behaviour Jido.VFS.Adapter
+
+    def starts_processes, do: false
+    def configure(opts), do: {__MODULE__, Map.new(opts)}
+    def unsupported_operations, do: [:read_stream, :write_stream, :append, :copy_between]
+    def versioning_module, do: nil
+
+    def write(%{test_pid: test_pid}, path, contents, opts) do
+      send(test_pid, {:copy_option_write, path, IO.iodata_to_binary(contents), opts})
+
+      if Keyword.has_key?(opts, :chunk_size) do
+        {:error, {:unexpected_chunk_size, opts}}
+      else
+        :ok
+      end
+    end
+
+    def write(_config, _path, _contents, _opts), do: :ok
+    def write_stream(_config, _path, _opts), do: unsupported(:write_stream)
+    def read(%{content: content}, _path), do: {:ok, content}
+    def read(_config, _path), do: {:error, Jido.VFS.Errors.FileNotFound.exception(file_path: "missing")}
+    def read_stream(_config, _path, _opts), do: unsupported(:read_stream)
+    def delete(_config, _path), do: :ok
+    def move(_config, _source, _destination, _opts), do: :ok
+    def copy(_config, _source, _destination, _opts), do: :ok
+    def copy(_source_config, _source, _destination_config, _destination, _opts), do: unsupported(:copy_between)
+    def file_exists(_config, _path), do: {:ok, :missing}
+    def list_contents(_config, _path), do: {:ok, []}
+    def create_directory(_config, _path, _opts), do: :ok
+    def delete_directory(_config, _path, _opts), do: :ok
+    def clear(_config), do: :ok
+    def set_visibility(_config, _path, _visibility), do: :ok
+    def visibility(_config, _path), do: {:ok, :public}
+
+    defp unsupported(operation) do
+      {:error, Jido.VFS.Errors.UnsupportedOperation.exception(operation: operation, adapter: __MODULE__)}
+    end
+  end
+
   describe "safe adapter configuration" do
     test "returns configured filesystem for valid adapter" do
       assert {:ok, {Jido.VFS.Adapter.Local, %Jido.VFS.Adapter.Local.Config{}}} =
@@ -76,6 +116,12 @@ defmodule JidoVFSTest do
 
     test "binary larger than chunk size returns multiple chunks" do
       assert Jido.VFS.chunk("hello world", 5) == ["hello", " worl", "d"]
+    end
+
+    test "invalid chunk size raises argument error" do
+      assert_raise ArgumentError, ~r/chunk size must be a positive integer/, fn ->
+        Jido.VFS.chunk("hello", 0)
+      end
     end
 
     test "binary much larger than chunk size returns many chunks" do
@@ -915,6 +961,54 @@ defmodule JidoVFSTest do
                )
 
       assert {:ok, "Hello Stream"} = Jido.VFS.read(filesystem_b, "copy.txt")
+    end
+
+    test "copy_between_filesystem stream strategy returns file not found for missing local source", %{
+      tmp_dir: prefix
+    } do
+      filesystem_a = Jido.VFS.Adapter.Local.configure(prefix: prefix)
+      filesystem_b = Jido.VFS.Adapter.InMemory.configure(name: InMemoryTest.MissingLocalStreamSource)
+
+      start_supervised(filesystem_b)
+
+      assert {:error, %Jido.VFS.Errors.FileNotFound{}} =
+               Jido.VFS.copy_between_filesystem(
+                 {filesystem_a, "missing.txt"},
+                 {filesystem_b, "copy.txt"},
+                 copy_between_strategy: :stream
+               )
+
+      assert {:ok, :missing} = Jido.VFS.file_exists(filesystem_b, "copy.txt")
+    end
+
+    test "copy_between_filesystem rejects invalid chunk size" do
+      filesystem_a = {CopyOptionCheckingAdapter, %{content: "Hello"}}
+      filesystem_b = {CopyOptionCheckingAdapter, %{test_pid: self()}}
+
+      assert {:error, %Jido.VFS.Errors.AdapterError{reason: %{reason: {:invalid_chunk_size, 0}}}} =
+               Jido.VFS.copy_between_filesystem(
+                 {filesystem_a, "source.txt"},
+                 {filesystem_b, "copy.txt"},
+                 copy_between_strategy: :stream,
+                 chunk_size: 0
+               )
+    end
+
+    test "copy_between_filesystem does not forward copy-only options to adapter writes" do
+      filesystem_a = {CopyOptionCheckingAdapter, %{content: "Hello Options"}}
+      filesystem_b = {CopyOptionCheckingAdapter, %{test_pid: self()}}
+
+      assert :ok =
+               Jido.VFS.copy_between_filesystem(
+                 {filesystem_a, "source.txt"},
+                 {filesystem_b, "copy.txt"},
+                 chunk_size: 2,
+                 visibility: :private
+               )
+
+      assert_receive {:copy_option_write, "copy.txt", "Hello Options", opts}
+      refute Keyword.has_key?(opts, :chunk_size)
+      assert Keyword.fetch!(opts, :visibility) == :private
     end
 
     test "copy_between_filesystem native strategy returns unsupported when adapter cannot copy_between" do

--- a/test/jido_vfs_test.exs
+++ b/test/jido_vfs_test.exs
@@ -300,6 +300,68 @@ defmodule JidoVFSTest do
       assert_in_list list, %Jido.VFS.Stat.File{name: "test.txt"}
       assert_in_list list, %Jido.VFS.Stat.File{name: "test-1.txt"}
     end
+
+    test "module wrapper exposes the full public filesystem API", %{tmp_dir: prefix} do
+      defmodule Local.FullApiTest do
+        use Jido.VFS.Filesystem,
+          adapter: Jido.VFS.Adapter.Local,
+          prefix: prefix
+      end
+
+      expected_exports = [
+        write_stream: 1,
+        write_stream: 2,
+        create_directory: 1,
+        create_directory: 2,
+        delete_directory: 1,
+        delete_directory: 2,
+        clear: 0,
+        clear: 1,
+        set_visibility: 2,
+        visibility: 1,
+        stat: 1,
+        access: 2,
+        append: 2,
+        append: 3,
+        truncate: 2,
+        utime: 2,
+        commit: 0,
+        commit: 1,
+        commit: 2,
+        revisions: 0,
+        revisions: 1,
+        revisions: 2,
+        read_revision: 2,
+        read_revision: 3,
+        rollback: 1,
+        rollback: 2
+      ]
+
+      for {function, arity} <- expected_exports do
+        assert function_exported?(Local.FullApiTest, function, arity)
+      end
+
+      assert {:ok, stream} = Local.FullApiTest.write_stream("nested/stream.txt")
+      Enum.into(["Hello", " ", "World"], stream)
+      assert {:ok, "Hello World"} = Local.FullApiTest.read("nested/stream.txt")
+
+      assert :ok = Local.FullApiTest.create_directory("empty/")
+      assert {:ok, %Jido.VFS.Stat.Dir{}} = Local.FullApiTest.stat("empty/")
+      assert :ok = Local.FullApiTest.delete_directory("empty/")
+
+      assert :ok = Local.FullApiTest.append("append.txt", "ab")
+      assert {:ok, "ab"} = Local.FullApiTest.read("append.txt")
+      assert :ok = Local.FullApiTest.truncate("append.txt", 1)
+      assert :ok = Local.FullApiTest.access("append.txt", [:read])
+      assert :ok = Local.FullApiTest.set_visibility("append.txt", :private)
+      assert {:ok, :private} = Local.FullApiTest.visibility("append.txt")
+
+      assert {:error, %Jido.VFS.Errors.UnsupportedOperation{operation: :commit}} =
+               Local.FullApiTest.commit()
+
+      assert :ok = Local.FullApiTest.clear()
+      assert {:ok, :missing} = Local.FullApiTest.file_exists("append.txt")
+    end
   end
 
   describe "filesystem with own processes" do

--- a/test/support/minio.ex
+++ b/test/support/minio.ex
@@ -1,6 +1,4 @@
 defmodule JidoVfsTest.Minio do
-  require Logger
-
   def start_link do
     cur = Process.flag(:trap_exit, true)
 

--- a/test/support/sprite_fake_client.ex
+++ b/test/support/sprite_fake_client.ex
@@ -388,13 +388,9 @@ defmodule JidoVfsTest.SpriteFakeClient do
 
     case File.open(path, write_mode) do
       {:ok, io_device} ->
-        result = IO.binwrite(io_device, data)
+        :ok = IO.binwrite(io_device, data)
         File.close(io_device)
-
-        case result do
-          :ok -> {"", 0}
-          {:error, reason} -> {"write error: #{inspect(reason)}\n", 1}
-        end
+        {"", 0}
 
       {:error, :enoent} ->
         {"write error: No such file or directory\n", 1}


### PR DESCRIPTION
## Summary
- expose the full Jido.VFS public API from module-based filesystem wrappers
- return typed errors for missing InMemory read streams to prevent empty successful copies
- fix S3 prefix handling for read streams, directory deletion, and internal object-key operations
- make Local write streams create missing parent directories

## Verification
- mix test test/jido_vfs_test.exs test/jido_vfs/adapter/local_test.exs test/jido_vfs/adapter/in_memory_test.exs test/jido_vfs/adapter/s3_test.exs
- mix test
- mix quality
- mix test test/jido_vfs/adapter/in_memory_integration_test.exs --include integration